### PR TITLE
Make sure draw() doesn’t crash if buffer_rgba is not defined

### DIFF
--- a/axescache.py
+++ b/axescache.py
@@ -131,7 +131,8 @@ class AxesCache(object):
     def draw(self, renderer, *args, **kwargs):
         if self._capture is None or not self._enabled:
             Axes.draw(self.axes, renderer, *args, **kwargs)
-            self._capture = RenderCapture(self.axes, renderer)
+            if hasattr(renderer, 'buffer_rgba'):
+                self._capture = RenderCapture(self.axes, renderer)
         else:
             self.axes.axesPatch.draw(renderer, *args, **kwargs)
             self._capture.draw(renderer, *args, **kwargs)


### PR DESCRIPTION
 (can occur for example when saving SVG files)
